### PR TITLE
fix mode hotkeys being consumed when switcher not visible

### DIFF
--- a/sxitch/Core/AppDelegate.swift
+++ b/sxitch/Core/AppDelegate.swift
@@ -254,6 +254,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.toggleMode(.quit)
         }
 
+        window.publisher(for: \.isVisible)
+            .removeDuplicates()
+            .sink { isVisible in
+                if isVisible {
+                    KeyboardShortcuts.enable([.hideMode, .quitMode])
+                } else {
+                    KeyboardShortcuts.disable([.hideMode, .quitMode])
+                }
+            }
+            .store(in: &cancellables)
+
+
         setupEventTap()
         setupAutoSelect()
         refreshCachedAppNames()


### PR DESCRIPTION
When the switcher was hidden, the hotkeys for the hide and quit modes was being consumed even tho the launcher wasn't visible. This fixes that