### PR TITLE
stop rotation in radial view

### DIFF
--- a/sxitch/Views/Layouts/CircleAppLayout.swift
+++ b/sxitch/Views/Layouts/CircleAppLayout.swift
@@ -41,7 +41,6 @@ struct CircleAppLayout: View {
                 let y = radius * CGFloat(sin(angle))
 
                 RunningAppCell(app: app, depth: typed.count, onTap: onTap)
-                    .rotationEffect(.radians(angle + .pi / 2))
                     .offset(x: x, y: y)
             }
         }


### PR DESCRIPTION
This stops the radial view icons from being rotated.
fixes #12 
