### PR TITLE
Fix hotkeys for modes and radial view icon turn

### DIFF
--- a/sxitch/Settings/CustomModesSettingsView.swift
+++ b/sxitch/Settings/CustomModesSettingsView.swift
@@ -36,7 +36,6 @@ struct CustomModesSettingsView: View {
                         }
                         Spacer()
                         KeyboardShortcuts.Recorder(for: .customMode(mode.id.uuidString))
-                            .disabled(atLimit)
                         Button {
                             editingIndex = index
                         } label: {

--- a/sxitch/Views/Layouts/CircleAppLayout.swift
+++ b/sxitch/Views/Layouts/CircleAppLayout.swift
@@ -41,7 +41,6 @@ struct CircleAppLayout: View {
                 let y = radius * CGFloat(sin(angle))
 
                 RunningAppCell(app: app, depth: typed.count, onTap: onTap)
-                    .rotationEffect(.radians(angle + .pi / 2))
                     .offset(x: x, y: y)
             }
         }


### PR DESCRIPTION
This stops hotkeys for modes not being configurable (in free plan)
fixes #15 
fixes #12 